### PR TITLE
Treat Tuples as collections; indicate that items that show up are separate allocations.

### DIFF
--- a/src/MemoryExaminer.jl
+++ b/src/MemoryExaminer.jl
@@ -20,12 +20,6 @@ macro inspect(obj)
     :($inspect($(esc(obj)), $(QuoteNode(obj))))
 end
 
-probably_a_collection(x::T) where T = probably_a_collection(T)
-probably_a_collection(x::Type{T}) where T = false
-const _collection_types = (AbstractArray, AbstractDict, AbstractSet)
-probably_a_collection(x::Type{<:Union{_collection_types...}}) = true
-
-
 inspect(@nospecialize obj) = inspect(obj, "obj")
 function inspect(@nospecialize(obj), name)
     TerminalMenus.config(scroll=:wrap,cursor='→')
@@ -47,7 +41,7 @@ function interactive_inspect_results(field_summary, path)
 
     is_collection = field_summary.is_collection
     num_children = length(field_summary.children)
-    request_str = is_collection ? "$num_children Indexes:" : "$num_children Fields:"
+    request_str = is_collection ? "$num_children Allocated Indexes:" : "$num_children Allocated Fields:"
     choice = _get_next_field_from_user(request_str, options)
     if choice == UP
         return

--- a/src/summarysize.jl
+++ b/src/summarysize.jl
@@ -26,7 +26,7 @@ end
 
 struct SummarySize
     seen::IdDict{Any,Any}
-    results::FieldResult
+    fieldresult::FieldResult
     frontier::Vector{FrontierNode}
     exclude::Any
     chargeall::Any
@@ -49,7 +49,7 @@ function summarysize(obj;
                      chargeall = Union{Core.TypeMapEntry, Method})
     @nospecialize obj exclude chargeall
     ss = SummarySize(obj, exclude, chargeall)
-    parent = ss.results
+    parent = ss.fieldresult
     size::Int = ss(parent,parentname,obj)
     while !isempty(ss.frontier)
         # DFS heap traversal of everything without a specialization
@@ -88,7 +88,7 @@ function summarysize(obj;
         if val !== nothing && !isa(val, Module) && (!isa(val, ss.exclude) || isa(x, ss.chargeall))
             fieldresult = get!(parent_result.children, name, FieldResult(type=typeof(val),parent=parent_result))
             valsize = ss(fieldresult, name, val)::Int
-            fieldresult.size = valsize
+            _finish_fieldresult(fieldresult, val, valsize)
             p = fieldresult.parent
             while p !== nothing
                 p.size += valsize
@@ -97,8 +97,15 @@ function summarysize(obj;
             size += valsize
         end
     end
-    ss.results.size = size
-    return ss.results
+    _finish_fieldresult(ss.fieldresult, obj, size)
+    return ss.fieldresult
+end
+function _finish_fieldresult(fieldresult, val, size)
+    fieldresult.size = size
+    # Mark Collection types not handled below
+    if val isa Tuple
+        fieldresult.is_collection = true
+    end
 end
 
 (ss::SummarySize)(fieldresult, name, @nospecialize obj) = _summarysize(ss, fieldresult, name, obj)


### PR DESCRIPTION
Call out in the UI "2 *Allocated* Fields", because non-allocated
(inlined) fields are accounted for in the size of the value itself:
```julia
julia> m = MixedAllocations(1,(2,3),4,5)
MixedAllocations(1, (2, 3), 4, 5)

julia> MemoryExaminer.@inspect m
————————————————————————————————————————————————————————————————————————————————————————————————————————
(m)::MixedAllocations => 56.0 B
2 Allocated Fields:
 → c::Int64 => 8.0 B
   d::Int64 => 8.0 B
   ↩
```