### PR TITLE
Add horizontal scrolling of long lines with arrow-keys

### DIFF
--- a/src/MemoryExaminer.jl
+++ b/src/MemoryExaminer.jl
@@ -10,6 +10,7 @@ using TerminalMenus
 using Humanize
 
 include("summarysize.jl")
+include("ui.jl")
 
 """
     @inspect x
@@ -70,7 +71,7 @@ const UP = -2
 function _get_next_field_from_user(request_str, option_strings)
     option_strings = [option_strings..., "↩"]
     height = displaysize(stdout)[1]
-    menu = RadioMenu(option_strings, pagesize=min(20, height-3))
+    menu = InspectMenu(option_strings, pagesize=min(20, height-3))
 
     choice = request(request_str, menu)
 

--- a/src/ui.jl
+++ b/src/ui.jl
@@ -1,0 +1,99 @@
+import TerminalMenus
+import TerminalMenus: request
+
+mutable struct CthulhuMenu <: TerminalMenus.AbstractMenu
+    options::Vector{String}
+    pagesize::Int
+    pageoffset::Int
+    selected::Int
+    toggle::Union{Nothing, Symbol}
+    sub_menu::Bool
+end
+
+function show_as_line(el)
+    reduced_displaysize = displaysize(stdout) .- (0, 3)
+    buf = IOBuffer()
+    show(IOContext(buf, :limit=>true, :displaysize=>reduced_displaysize), el)
+    String(take!(buf))
+end
+
+
+function CthulhuMenu(callsites; pagesize::Int=10, sub_menu = false)
+    options = vcat(map(show_as_line, callsites), ["↩"])
+    length(options) < 1 && error("CthulhuMenu must have at least one option")
+
+    # if pagesize is -1, use automatic paging
+    pagesize = pagesize == -1 ? length(options) : pagesize
+    # pagesize shouldn't be bigger than options
+    pagesize = min(length(options), pagesize)
+    # after other checks, pagesize must be greater than 1
+    pagesize < 1 && error("pagesize must be >= 1")
+
+    pageoffset = 0
+    selected = -1 # none
+
+    CthulhuMenu(options, pagesize, pageoffset, selected, nothing, sub_menu)
+end
+
+TerminalMenus.options(m::CthulhuMenu) = m.options
+TerminalMenus.cancel(m::CthulhuMenu) = m.selected = -1
+
+function TerminalMenus.header(m::CthulhuMenu)
+    m.sub_menu && return ""
+    """
+    Select a call to descend into or ↩ to ascend. [q]uit.
+    Toggles: [o]ptimize, [w]arn, [d]ebuginfo, [s]yntax highlight for Source/LLVM/Native.
+    Show: [S]ource code, [A]ST, [L]LVM IR, [N]ative code
+    Advanced: dump [P]arams cache.
+    """
+end
+
+function TerminalMenus.keypress(m::CthulhuMenu, key::UInt32)
+    m.sub_menu && return false
+    if key == UInt32('w')
+        m.toggle = :warn
+        return true
+    elseif key == UInt32('o')
+        m.toggle = :optimize
+        return true
+    elseif key == UInt32('d')
+        m.toggle = :debuginfo
+        return true
+    elseif key == UInt32('s')
+        m.toggle = :highlighter
+        return true
+   elseif key == UInt32('S')
+        m.toggle = :source
+        return true
+   elseif key == UInt32('A')
+        m.toggle = :ast
+        return true
+    elseif key == UInt32('L')
+        m.toggle = :llvm
+        return true
+    elseif key == UInt32('N')
+        m.toggle = :native
+        return true
+    elseif key == UInt32('P')
+        m.toggle = :dump_params
+        return true
+    end
+    return false
+end
+
+function TerminalMenus.pick(menu::CthulhuMenu, cursor::Int)
+    menu.selected = cursor
+    return true #break out of the menu
+end
+
+function TerminalMenus.writeLine(buf::IOBuffer, menu::CthulhuMenu, idx::Int, cursor::Bool, term_width::Int)
+    cursor_len = length(TerminalMenus.CONFIG[:cursor])
+    # print a ">" on the selected entry
+    cursor ? print(buf, TerminalMenus.CONFIG[:cursor]) : print(buf, repeat(" ", cursor_len))
+    print(buf, " ") # Space between cursor and text
+
+    line = replace(menu.options[idx], "\n" => "\\n")
+    line = TerminalMenus.trimWidth(line, term_width, !cursor, cursor_len)
+
+    print(buf, line)
+end


### PR DESCRIPTION
Copy custom `TerminalView` menu code from https://github.com/JuliaDebug/Cthulhu.jl/blob/master/src/ui.jl.

Update to add horizontal scrolling for long lines with left/right arrow keys.