### PR TITLE
Press `v` to toggle showing the value of the current field.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 Humanize = "7ec9b9c5-1998-51e1-b7fc-fc3590c18259"
+REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 TerminalMenus = "dc548174-15c3-5faf-af27-7997cfbde655"
 
 [compat]

--- a/src/ioutils.jl
+++ b/src/ioutils.jl
@@ -1,0 +1,64 @@
+module IOUtils
+
+"""
+    WriteBlockingIO(buf=0; spawn=false) do io ... end
+    WriteBlockingIO(buf=0)
+
+Create a blocking IO object which blocks character entry (when the buffer is full). This is
+useful if you have a function that may take a really long time to potentially write
+thousands or millions of characters, but you only want the first 10.
+
+If you create the WriteBlockingIO object with an associated function, that function will be
+spawned concurrently. If you close the io object, an exception will be thrown on subsequent
+writes, killing the spawned Task if unhandled.
+
+# Example
+```julia-repl
+julia> io = WriteBlockingIO() do io
+           println(io, collect(1:1_000_000))
+       end
+WriteBlockingIO(Channel{UInt8}(sz_max:0,sz_curr:1))
+
+julia> String(take_up_to_n!(io, 10))
+"[1, 2, 3, "
+
+julia> close(io)
+
+julia> String(take_up_to_n!(io, 10))
+ERROR: ArgumentError: read failed, WriteBlockingIO is already closed.
+```
+"""
+struct WriteBlockingIO <: IO
+    ch :: Channel{UInt8}
+    WriteBlockingIO(buf=0) = new(Channel{UInt8}(buf))
+    function WriteBlockingIO(f::Function, buf=0; spawn=false)
+        new(Channel{UInt8}(ch -> f(new(ch)), buf; spawn=spawn))
+    end
+end
+
+Base.write(io::WriteBlockingIO, c::UInt8) = put!(io.ch, c)
+Base.close(io::WriteBlockingIO) = close(io.ch)
+Base.isopen(io::WriteBlockingIO) = isopen(io.ch)
+
+Base.take!(io::WriteBlockingIO) = collect(io.ch)
+function take_up_to_n!(io::WriteBlockingIO, n)
+    if !isopen(io.ch) && !isready(io.ch)
+        throw(ArgumentError("read failed, WriteBlockingIO is already closed."))
+    end
+    out = UInt8[]
+    for i in 1:n
+        if !isopen(io.ch) && !isready(io.ch) break end
+        try
+            push!(out, take!(io.ch))
+        catch e
+            if e isa InvalidStateException
+                break
+            else
+                rethrow()
+            end
+        end
+    end
+    out
+end
+
+end # module IOUtils

--- a/src/selection_ui.jl
+++ b/src/selection_ui.jl
@@ -49,15 +49,15 @@ TerminalMenus.cancel(m::InspectMenu) = m.selected = -1
 TerminalMenus.header(m::InspectMenu) = ""
 
 function TerminalMenus.keypress(m::InspectMenu, key::UInt32)
-    #if key == UInt32('w')
-    #    m.toggle = :warn
-    #    return true
     if key == Int(TerminalMenus.ARROW_RIGHT)
         m.scroll_horizontal -= 1
     elseif key == Int(TerminalMenus.ARROW_LEFT)
         m.scroll_horizontal += 1
     elseif key == Int('J')
         m.selected_command = SelectionOptions.JUMP
+        return true
+    elseif key == UInt32('v')
+        m.selected_command = SelectionOptions.TOGGLE_VALUE
         return true
     end
     return false


### PR DESCRIPTION
Press `v` to toggle showing the value of the current field.

We retrieve the first line of `show(eval(field_path))`, terminating the Task after it's printed one line, so it doesn't hang if you try to print a very large object.

To achieve that termination, this PR also defines a small helper utility, `WriteBlockingIO <: IO` which blocks a task on printing each character, and throws an exception to that task when you close the IO.

Example:
```julia
————————————————————————————————————————————————————————————————————
Select a field to recurse into or ↩ to ascend. [q]uit.

Commands: [J]ump to field path.  Toggle [V]alue.
Toggles: [v]alue of the current field.

(d.vals[7])::Tuple{Int64,Int64} => 16.0 B
0 Allocated Indexes:
 → ↩

————————————————————————————————————————————————————————————————————
Select a field to recurse into or ↩ to ascend. [q]uit.

Commands: [J]ump to field path.  Toggle [V]alue.
Toggles: [v]alue of the current field.

(2, 3) => 16.0 B
0 Allocated Indexes:
 → ↩
```