### PR TITLE
Add basic ability to export a PProf profile of memory usage

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,9 @@ version = "0.1.0"
 
 [deps]
 Humanize = "7ec9b9c5-1998-51e1-b7fc-fc3590c18259"
+OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+PProf = "e4faabce-9ead-11e9-39d9-4379958e3056"
+ProtoBuf = "3349acd9-ac6a-5e09-bcdb-63829b23a429"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 TerminalMenus = "dc548174-15c3-5faf-af27-7997cfbde655"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MemoryInspector"
 uuid = "86003188-52e7-4782-9607-153a7cbed274"
 authors = ["Nathan Daly <nhdaly@gmail.com>"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 Humanize = "7ec9b9c5-1998-51e1-b7fc-fc3590c18259"

--- a/src/MemoryInspector.jl
+++ b/src/MemoryInspector.jl
@@ -23,6 +23,7 @@ end
 include("summarysize.jl")
 include("ioutils.jl")
 include("selection_ui.jl")
+include("pprof_export.jl")
 
 # Toggle whether we show a value or the field path
 const _show_value = Ref(false)
@@ -110,7 +111,7 @@ function interactive_inspect_results(user_module, field_summary, path)
         choice = _get_next_field_from_user(request_str, options)
         if choice isa Integer
             (name,field) = children[choice]
-            newpath = is_collection ? "$path[$name]" : "$path.$name"
+            newpath = _path_str(path, field_summary, name)
             interactive_inspect_results(user_module, field, newpath)
         elseif choice isa SelectionOptions.Option
             if choice === SelectionOptions.UP
@@ -138,6 +139,10 @@ function interactive_inspect_results(user_module, field_summary, path)
             rethrow()
         end
     end
+end
+function _path_str(parent_path, field_summary, name)
+    is_collection = field_summary.is_collection
+    newpath = is_collection ? "$parent_path[$name]" : "$parent_path.$name"
 end
 _field_size(f) = f.skipped_self_reference ? "<self-reference>" : Humanize.datasize(f.size, style=:bin)
 

--- a/src/MemoryInspector.jl
+++ b/src/MemoryInspector.jl
@@ -1,6 +1,6 @@
 module MemoryInspector
 
-export @inspect
+export @inspect, @mem_pprof
 
 # Use README as module docstring
 @doc let path = joinpath(dirname(@__DIR__), "README.md")

--- a/src/pprof_export.jl
+++ b/src/pprof_export.jl
@@ -45,8 +45,8 @@ using Base.StackTraces: StackFrame
 # - Mappings
 
 """
-    @pprof [kwargs...] object
-    @pprof webport=62261 out="mem-inspect-profile" [...] object
+    @mem_pprof [kwargs...] object
+    @mem_pprof webport=62261 out="mem-inspect-profile" [...] object
 
 Collects detailed breakdown of the recursive size information for `object`, via
 the functionality provided by MemoryInspector.jl, and exports it to a profile in the
@@ -76,7 +76,7 @@ If you manually edit the output file or want to point at an existing profile obj
 - `ui_relative_percentages`: Passes `-relative_percentages` to pprof. Causes nodes
   ignored/hidden through the web UI to be ignored from totals when computing percentages.
 """
-macro pprof(exs...)
+macro mem_pprof(exs...)
     args = exs[1:end-1]
     e = exs[end]
     :(_pprof($(string(e)), $(esc(e)); $((esc(a) for a in args)...)))

--- a/src/pprof_export.jl
+++ b/src/pprof_export.jl
@@ -8,23 +8,6 @@ using OrderedCollections
 
 using MemoryInspector.MemorySummarySize: FieldResult
 
-function iterate_summary_result(
-    parent_name,
-    top_level_field_result::FieldResult,
-)
-    return Channel() do ch
-        parent_path = parent_name
-        parent_field = top_level_field_result
-        key = String[]
-
-        for (name,field) in parent_field.children
-            push!(key, name)
-            put!(ch,
-                MemoryInspector._path_str(parent_path, parent_field, name) =>
-                    field)
-        end
-    end
-end
 
 struct FieldTraversalNode
     path::String

--- a/src/pprof_export.jl
+++ b/src/pprof_export.jl
@@ -1,0 +1,266 @@
+# Import the PProf generated protobuf types from the PProf package:
+import PProf
+import PProf.perftools.profiles: ValueType, Sample, Function, Location, Line, Label
+const PProfile = PProf.perftools.profiles.Profile
+
+using ProtoBuf
+using OrderedCollections
+
+using MemoryInspector.MemorySummarySize: FieldResult
+
+function iterate_summary_result(
+    parent_name,
+    top_level_field_result::FieldResult,
+)
+    return Channel() do ch
+        parent_path = parent_name
+        parent_field = top_level_field_result
+        key = String[]
+
+        for (name,field) in parent_field.children
+            push!(key, name)
+            put!(ch,
+                MemoryInspector._path_str(parent_path, parent_field, name) =>
+                    field)
+        end
+    end
+end
+
+struct FieldTraversalNode
+    path::String
+    parent_field::Union{Nothing,FieldResult}
+    name::String
+    field::FieldResult
+end
+
+"""
+    _enter!(dict::OrderedDict{T, Int64}, key::T) where T
+
+Resolves from `key` to the index (zero-based) in the dict.
+Useful for the Strings table
+
+NOTE: We must use Int64 throughout this package (regardless of system word-size) b/c the
+proto file specifies 64-bit integers.
+"""
+function _enter!(dict::OrderedDict{T, Int64}, key::T) where T
+    if haskey(dict, key)
+        return dict[key]
+    else
+        l = Int64(length(dict))
+        dict[key] = l
+        return l
+    end
+end
+
+using Base.StackTraces: StackFrame
+
+# TODO:
+# - Mappings
+
+macro pprof(exs...)
+    args = exs[1:end-1]
+    e = exs[end]
+    :(_pprof($(string(e)), $(esc(e)); $((esc(a) for a in args)...)))
+end
+
+"""
+    _pprof(name, obj;
+            web = true, webhost = "localhost", webport = 57599,
+            out = "profile.pb.gz", from_c = true, drop_frames = "", keep_frames = "",
+            ui_relative_percentages = true,
+         )
+
+Fetches the collected `Profile` data, exports to the `pprof` format, and (optionally) opens
+a `pprof` web-server for interactively viewing the results.
+
+If `web=true`, the web-server is opened in the background. Re-running `pprof()` will refresh
+the web-server to use the new output.
+
+If you manually edit the output file, `PProf.refresh()` will refresh the server without
+overwriting the output file. `PProf.kill()` will kill the server.
+
+# Arguments:
+- `data::Vector{UInt}`: The data provided by `Profile.fetch` [optional].
+
+# Keyword Arguments
+- `web::Bool`: Whether to launch the `go tool pprof` interactive webserver for viewing results.
+- `webhost::AbstractString`: If using `web`, which host to launch the webserver on.
+- `webport::Integer`: If using `web`, which port to launch the webserver on.
+- `out::String`: Filename for output.
+- `from_c::Bool`: If `false`, exclude frames that come from from_c. Defaults to `true`.
+- `drop_frames`: frames with function_name fully matching regexp string will be dropped from the samples,
+                 along with their successors.
+- `keep_frames`: frames with function_name fully matching regexp string will be kept, even if it matches drop_functions.
+- `ui_relative_percentages`: Passes `-relative_percentages` to pprof. Causes nodes
+  ignored/hidden through the web UI to be ignored from totals when computing percentages.
+"""
+function _pprof(top_level_path::String, @nospecialize(obj),
+               ;
+               web::Bool = true,
+               webhost::AbstractString = "localhost",
+               webport::Integer = 57599,
+               out::AbstractString = "mem-inspect-profile.pb.gz",
+               from_c::Bool = true,
+               drop_frames::Union{Nothing, AbstractString} = nothing,
+               keep_frames::Union{Nothing, AbstractString} = nothing,
+               ui_relative_percentages::Bool = true,
+            )
+    field_summary = MemorySummarySize.summarysize(obj, parentname=top_level_path)
+
+    period = UInt64(0x1)
+
+    @assert !isempty(basename(out)) "`out=` must specify a file path to write to. Got unexpected: '$out'"
+    if !endswith(out, ".pb.gz")
+        out = "$out.pb.gz"
+        @info "Writing output to $out"
+    end
+
+    string_table = OrderedDict{AbstractString, Int64}()
+    enter!(string) = _enter!(string_table, string)
+    enter!(::Nothing) = _enter!(string_table, "nothing")
+    ValueType!(_type, unit) = ValueType(_type = enter!(_type), unit = enter!(unit))
+
+    # Setup:
+    enter!("")  # NOTE: pprof requires first entry to be ""
+    # Functions need a uid, we'll use the pointer for the method instance
+    seen_funcs = Set{UInt64}()
+    funcs = Dict{UInt64, Function}()
+
+    seen_locs = Set{UInt64}()
+    locs  = Dict{UInt64, Location}()
+
+    sample_type = [
+        ValueType!("instances", "count"), # Mandatory
+        ValueType!("size", "bytes")
+    ]
+
+    prof = PProfile(
+        sample = [], location = [], _function = [],
+        mapping = [], string_table = [],
+        sample_type = sample_type, default_sample_type = 2, # size
+        period = period, period_type = ValueType!("heap", "bytes")
+    )
+
+    if drop_frames !== nothing
+        prof.drop_frames = enter!(drop_frames)
+    end
+    if keep_frames !== nothing
+        prof.keep_frames = enter!(keep_frames)
+    end
+
+    # Mappings to PProf:
+    #  Type of the element => Function
+    #  instance objectid => IP
+    #  path to the element => Stack Trace
+
+    # start decoding backtraces
+    location_ids = Vector{UInt64}()
+    nodes_stack = Vector{Union{Nothing,FieldTraversalNode}}()
+    # start with the root node argument.
+    push!(nodes_stack, FieldTraversalNode("", nothing, top_level_path, field_summary))
+
+    while !isempty(nodes_stack)
+        node = pop!(nodes_stack)
+        if node === nothing
+            # nothing means we've finished iterating all children of a node, and are popping
+            # up to the parent.
+            pop!(location_ids)
+            continue
+        end
+        field = node.field
+
+        # At each node in the tree, we create an entry for that element
+        if node.parent_field === nothing  # Special-case the first node
+            path = node.name
+        else
+            path = MemoryInspector._path_str(node.path, node.parent_field, node.name)
+        end
+
+        ip = field.objectid
+
+        # A backtrace consists of a set of IP (Instruction Pointers), each IP points
+        # a single line of code and `litrace` has the necessary information to decode
+        # that IP to a specific frame (or set of frames, if inlining occured).
+
+        # if we have already seen this IP avoid decoding it again
+        #if ip in seen_locs
+        #    push!(location_ids, ip)
+        #    continue
+        #end
+        #push!(seen_locs, ip)
+
+        # Decode the IP into information about this stack frame (or frames given inlining)
+        location = Location(;line=[])
+
+        # Record a new frame for this object instance
+        begin
+            frame = field.type
+
+            if ip == 0
+                ip = UInt64(frame.uid)
+            end
+            location.address = UInt64(frame.uid)
+            location.id = ip
+            # TODO: Line numbers? (A line number is required, so we use fake number here)
+            push!(location.line, Line(function_id = ip, line = 1))
+
+            # Store the function in our functions dict
+            funcProto = Function()
+            funcProto.id = ip
+            funcProto.name = enter!(string(frame))
+            # TODO: Line numbers?
+            funcProto.start_line = convert(Int64, 1)
+            # TODO: File names?
+            # TODO: We could consider generating temp files with the `dump()` of the
+            # type? :/ that's not ideal...
+            # Or maybe we can find the file from the method table for the type?
+            #file = Base.find_source_file(file)
+            file = "<nofile>"
+            funcProto.filename   = enter!(file)
+            funcProto.system_name = funcProto.name
+            funcs[ip] = funcProto
+        end
+
+        locs[ip] = location
+        push!(location_ids, ip)
+
+        begin
+            # Record for this element in the struct tree.
+            flat_size = field.size - sum([0, (c.size for (_,c) in field.children)...])
+            value = [
+                1,              # events  TODO: should we actually put the size here instead?
+                flat_size,     # size of the element
+            ]
+            push!(prof.sample, Sample(;
+                    label= [Label(key=enter!(""), str=enter!(path))],
+                    location_id = reverse(location_ids),
+                    value = value,
+                ))
+        end
+
+
+        push!(nodes_stack, nothing)
+        for (name, child_field) in field.children
+            push!(nodes_stack, FieldTraversalNode(path, field, name, child_field))
+        end
+    end
+
+    # Build Profile
+    prof.string_table = collect(keys(string_table))
+    # If from_c=false funcs and locs should NOT contain C functions
+    prof._function = collect(values(funcs))
+    prof.location  = collect(values(locs))
+
+    # Write to disk
+    open(out, "w") do io
+        writeproto(io, prof)
+    end
+
+    if web
+        PProf.refresh(webhost = webhost, webport = webport, file = out,
+                      #ui_relative_percentages = ui_relative_percentages)
+        )
+    end
+
+    out
+end

--- a/src/summarysize.jl
+++ b/src/summarysize.jl
@@ -7,6 +7,9 @@ using Core: SimpleVector
 using Base: unsafe_convert, isbitsunion, unwrap_unionall, isdeprecated, gc_alignment
 
 Base.@kwdef mutable struct FieldResult
+    # The unique id for the FieldResultalue itself
+    objectid::UInt = 0x0
+
     size::Int = 0
     type::Type
     is_collection::Bool = false
@@ -16,7 +19,7 @@ Base.@kwdef mutable struct FieldResult
 end
 function Base.show(io::IO, fr::FieldResult)
     # Print everything but parent
-    print(io,"FieldResult($(fr.size), $(fr.type), $(fr.is_collection), $(fr.children))")
+    print(io,"FieldResult($(fr.objectid), $(fr.size), $(fr.type), $(fr.is_collection), $(fr.children))")
 end
 
 mutable struct FrontierNode
@@ -102,6 +105,7 @@ function summarysize(obj;
     return ss.fieldresult
 end
 function _finish_fieldresult(fieldresult, val, size)
+    fieldresult.objectid = Base.objectid(val)
     fieldresult.size = size
     # Mark Collection types not handled below
     if val isa Tuple


### PR DESCRIPTION
Uses the PProf package to export and open an interactive graph view of how bytes are allocated by type within a given structure.

It still doesn't do a great job distinguishing between multiple instances of the same type within a given parent, but it's pretty good.

----

I'm also not sure if it makes more sense to add this PProf integration here, or to use MemoryInspector in PProf to provide a memory view from PProf.jl. I think it makes more sense here?

As an example:
```julia
julia> d = Dict(1=>2, 2=>"hello", 3=>"hi", ("hi",2)=>3)
Dict{Any,Any} with 4 entries:
  2         => "hello"
  3         => "hi"
  ("hi", 2) => 3
  1         => 2

julia> MemoryInspector.@pprof web=true webport=23222 d
"mem-inspect-profile.pb.gz"

Serving web UI on http://localhost:23222
```

<img width="435" alt="Screen Shot 2020-06-03 at 9 00 58 PM" src="https://user-images.githubusercontent.com/1582097/83703382-70f9dc80-a5dd-11ea-978a-b6f962bab4ed.png">
<img width="980" alt="Screen Shot 2020-06-03 at 9 05 35 PM" src="https://user-images.githubusercontent.com/1582097/83703573-01d0b800-a5de-11ea-8e8b-dcddc479b4da.png">

