### PR TITLE
Use stdlib REPL.TerminalMenus

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MemoryInspector"
 uuid = "86003188-52e7-4782-9607-153a7cbed274"
 authors = ["Nathan Daly <nhdaly@gmail.com>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Humanize = "7ec9b9c5-1998-51e1-b7fc-fc3590c18259"
@@ -9,11 +9,9 @@ OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 PProf = "e4faabce-9ead-11e9-39d9-4379958e3056"
 ProtoBuf = "3349acd9-ac6a-5e09-bcdb-63829b23a429"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
-TerminalMenus = "dc548174-15c3-5faf-af27-7997cfbde655"
 
 [compat]
 Humanize = "1.0"
-TerminalMenus = "0.1"
 OrderedCollections = "1"
 PProf = "1"
 ProtoBuf = "0.7, 0.8"

--- a/src/MemoryInspector.jl
+++ b/src/MemoryInspector.jl
@@ -8,6 +8,10 @@ export @inspect, @mem_pprof
     read(path, String)
 end MemoryInspector
 
+if VERSION >= v"1.5-" || VERSION < v"1.4-"
+    @warn "Only Julia version 1.4 is supported. Beware this may segfault!"
+end
+
 using Humanize
 import REPL
 using REPL.TerminalMenus

--- a/src/MemoryInspector.jl
+++ b/src/MemoryInspector.jl
@@ -8,9 +8,9 @@ export @inspect, @mem_pprof
     read(path, String)
 end MemoryInspector
 
-using TerminalMenus
 using Humanize
 import REPL
+using REPL.TerminalMenus
 
 module SelectionOptions
     @enum Option begin

--- a/src/selection_ui.jl
+++ b/src/selection_ui.jl
@@ -1,7 +1,8 @@
 module SelectionUI
 
-import TerminalMenus
-import TerminalMenus: request
+import REPL
+import REPL.TerminalMenus
+using REPL.TerminalMenus: request  # Called from parent package
 
 using ..MemoryInspector: SelectionOptions
 
@@ -68,7 +69,9 @@ function TerminalMenus.pick(menu::InspectMenu, cursor::Int)
     return true #break out of the menu
 end
 
-function TerminalMenus.writeLine(buf::IOBuffer, menu::InspectMenu, idx::Int, cursor::Bool, term_width::Int)
+function TerminalMenus.writeLine(buf::IOBuffer, menu::InspectMenu, idx::Int, cursor::Bool)
+    term_width = REPL.Terminals.width(TerminalMenus.terminal)
+
     cursor_len = length(TerminalMenus.CONFIG[:cursor])
     # print a ">" on the selected entry
     cursor ? print(buf, TerminalMenus.CONFIG[:cursor]) : print(buf, repeat(" ", cursor_len))


### PR DESCRIPTION
For now, we are switching to stdlib REPL.TerminalMenus to avoid compat bounds on the `Compat` package.

The TerminalMenus.jl package has an upper bound on Compat, which means
it cannot be used with more recent packages. This means that
MemoryInspector currently _also_ cannot be used in environments with
more recent packages, so we're dropping our usage of TerminalMenus.jl.